### PR TITLE
Add HTML 404 File

### DIFF
--- a/src/libambition/Controller/Static.vala
+++ b/src/libambition/Controller/Static.vala
@@ -82,12 +82,12 @@ namespace Ambition.Controller {
 				response.status = 404;
 
 				// Show a sane 404. For SEO and other reasons - This must exist.
-				if(file_404_exists == "") {
-					response.body = "404";
-					return new CoreView.None();
-				} else {
+				if(file_404_exists == "yes") {
 					var file_404 = File.new_for_path( Config.lookup_with_default( "static.root", "static" ) + "/404.html" );
 					return new CoreView.File(file_404);
+				} else {
+					response.body = "404";
+					return new CoreView.None();
 				}
 			}
 			return new CoreView.File(file);

--- a/src/libambition/Controller/Static.vala
+++ b/src/libambition/Controller/Static.vala
@@ -1,6 +1,6 @@
 /*
  * Static.vala
- * 
+ *
  * The Ambition Web Framework
  * http://www.ambitionframework.org
  *
@@ -35,6 +35,7 @@ namespace Ambition.Controller {
 		public static ArrayList<Ambition.Action?> add_actions() {
 			var actions = new ArrayList<Ambition.Action?>();
 			string[] directories = Config.lookup_with_default( "static.directories", "" ).split(",");
+			string file_404_exists = Config.lookup_with_default( "static.file_404_exists", "" );
 			var s = new Static();
 
 			// Add favicon.ico
@@ -78,8 +79,15 @@ namespace Ambition.Controller {
 			var file = File.new_for_path( Config.lookup_with_default( "static.root", "static" ) + path );
 			if ( !file.query_exists() ) {
 				response.status = 404;
-				response.body = "";
-				return new CoreView.None();
+
+				// Show a sane 404. For SEO and other reasons - This must exist.
+				if(file_404_exists == "") {
+					response.body = "404";
+					return new CoreView.None();
+				} else {
+					var file_404 = File.new_for_path( Config.lookup_with_default( "static.root", "static" ) + "/404.html" );
+					return new CoreView.File(file_404);
+				}
 			}
 			return new CoreView.File(file);
 		}

--- a/src/libambition/Controller/Static.vala
+++ b/src/libambition/Controller/Static.vala
@@ -35,7 +35,6 @@ namespace Ambition.Controller {
 		public static ArrayList<Ambition.Action?> add_actions() {
 			var actions = new ArrayList<Ambition.Action?>();
 			string[] directories = Config.lookup_with_default( "static.directories", "" ).split(",");
-			string file_404_exists = Config.lookup_with_default( "static.file_404_exists", "" );
 			var s = new Static();
 
 			// Add favicon.ico
@@ -72,6 +71,8 @@ namespace Ambition.Controller {
 		 */
 		public Result show_static_file( State state ) {
 			string path = state.request.path;
+			string file_404_exists = Config.lookup_with_default( "static.file_404_exists", "" );
+
 			Response response = state.response;
 			if ( path.length > 7 && path.substring( 0, 7 ) == "/static" ) {
 				path = path.substring(7);

--- a/src/libambition/Controller/Static.vala
+++ b/src/libambition/Controller/Static.vala
@@ -72,6 +72,7 @@ namespace Ambition.Controller {
 		public Result show_static_file( State state ) {
 			string path = state.request.path;
 			string file_404_exists = Config.lookup_with_default( "static.file_404_exists", "" );
+			string file_404_path = Config.lookup_with_default( "static.file_404_exists", "" );
 
 			Response response = state.response;
 			if ( path.length > 7 && path.substring( 0, 7 ) == "/static" ) {
@@ -83,7 +84,7 @@ namespace Ambition.Controller {
 
 				// Show a sane 404. For SEO and other reasons - This must exist.
 				if(file_404_exists == "yes") {
-					var file_404 = File.new_for_path( Config.lookup_with_default( "static.root", "static" ) + "/404.html" );
+					var file_404 = File.new_for_path( Config.lookup_with_default( "static.root", "static" ) + file_404_path );
 					return new CoreView.File(file_404);
 				} else {
 					response.body = "404";

--- a/src/libambition/Dispatcher.vala
+++ b/src/libambition/Dispatcher.vala
@@ -353,8 +353,6 @@ namespace Ambition {
 					}
 
 					return action.targets;
-				} else {
-					logger.info( "404 Route Not Found '%s'.".printf(action_pattern) );
 				}
 			}
 			return null;

--- a/src/libambition/Dispatcher.vala
+++ b/src/libambition/Dispatcher.vala
@@ -70,7 +70,7 @@ namespace Ambition {
 			Config.set_value( "ambition.app_name", executable_path.substring( last_index + 1 ) );
 			Config.set_value( "ambition.app_path", executable_path.substring( 0, last_index ) );
 		}
-		
+
 		public bool run() {
 			if ( actions == null ) {
 				logger.error("No actions specified, nothing to do!");
@@ -161,8 +161,8 @@ namespace Ambition {
 			this.engine.execute();
 			return true;
 		}
-		
-		/** 
+
+		/**
 		 * Initialize our State with new Response and Request objects,
 		 * etc. To be called immediately upon request acceptance by an
 		 * Engine.
@@ -353,6 +353,8 @@ namespace Ambition {
 					}
 
 					return action.targets;
+				} else {
+					logger.info( "404 Route Not Found '%s'.".printf(action_pattern) );
 				}
 			}
 			return null;


### PR DESCRIPTION
Google/Bing place very high priority on sane 404 pages. Not to mention from a marketing standpoint a sane 404 page can make the difference between leaving a website and being sucked into another article.

This PR allows for a basic 404.html file to be used - Ideally a 404 Controller should exist for dynamics and fun. But for right now - this will work. 

Give users a pretty 404 page instead of a blank page.